### PR TITLE
Populate course schedule in mock data relative to current time

### DIFF
--- a/entry/app.py
+++ b/entry/app.py
@@ -111,8 +111,9 @@ async def get_data(request: Request) -> HTTPResponse:
         return text(mock.replace('%random%', str(random.randint(0, 1))), content_type="application/json")
 
     if username == 'test2' or (username == '19050069' and password == '19050069'):
-        return text(httpx.get('https://schoolpower.oss-cn-shanghai.aliyuncs.com/test/test_v2_full.json').text,
-                    content_type="application/json")
+        mock = httpx.get('https://schoolpower.oss-cn-shanghai.aliyuncs.com/test/test_v2_full.json').text
+        augmented = parser.augment_test_data_with_schedule(mock)
+        return json(augmented.to_dict())
 
     start_time = time.time()
     api = PowerSchoolApi(PS_API, CACHE_DB_LOCATION)

--- a/powerschool/parser.py
+++ b/powerschool/parser.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+import datetime
 
 from .model import *
 
@@ -120,6 +121,29 @@ def parse(student_data: Any) -> StudentData:
     )
 
     return parse_result
+
+
+def augment_test_data_with_schedule(raw: Any) -> StudentData:
+    """
+    Requires at least 5 different courses
+    """
+    mock = StudentData().from_json(raw)
+    now = datetime.datetime.now()
+    today = datetime.date.today()
+    from_monday = datetime.timedelta(days=today.weekday())
+    for day in range(5):
+        for course in range(5):
+            start = now - from_monday + datetime.timedelta(days=day) + datetime.timedelta(hours=course - 1)
+            end = start + datetime.timedelta(minutes=55)
+            if not hasattr(mock.courses[course], "schedule"):
+                mock.courses[course].schedule = []
+            mock.courses[course].schedule.append(
+                CourseSchedule(
+                    start_time=int(start.timestamp() * 1000),
+                    end_time=int(end.timestamp() * 1000)
+                )
+            )
+    return mock
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since the system time can't be changed in e2e tests (SSL cert validation), this enables the schedule to look nice in screenshots.

![3_schedule_1_A58ADBEB-2750-41AE-AC5A-21CDB0C6DA25](https://user-images.githubusercontent.com/16971971/145488532-91183e7d-376e-460a-bd93-2ad49fd809cc.png)
